### PR TITLE
Patch to openssl-1.1.1zd. Resolved vulnerability: CVE-2025-9230

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,19 @@
  https://github.com/openssl/openssl/commits/ and pick the appropriate
  release branch.
 
+ Changes between 1.1.1zb_p2 and 1.1.1zd [30 Sep 2025]
+
+ *) Fix Out-of-bounds read & write in RFC 3211 KEK Unwrap
+
+    the consequences of a successful exploit of this vulnerability could be 
+    severe, the probability that the attacker would be able to perform it 
+    is low. Besides, password based (PWRI) encryption support in CMS messages
+    is very rarely used.
+
+    [CVE-2025-9230]
+    [Stanislav Fort]
+
+
  Changes between 1.1.1zb_p1 and 1.1.1zb_p2 [20 Jan 2025]
 
  *) Fix timing side-channel in ECDSA signature computation

--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,10 @@
   This file gives a brief overview of the major changes between each OpenSSL
   release. For more details please read the CHANGES file.
 
+  Major changes between 1.1.1zb_p2 and 1.1.1zd [30 Sep 2025]
+
+      o Fix Out-of-bounds read & write in RFC 3211 KEK Unwrap (CVE-2025-9230)
+
   Major changes between OpenSSL 1.1.1zb and OpenSSL 1.1.1zb_p2 [20 Jan 2025]
 
       o Fix version number for versions that require two letters

--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 
- OpenSSL 1.1.1zb_p2 20 Jan 2025
+ OpenSSL 1.1.1zd  30 Sep 2025
 
  Copyright (c) 1998-2023 The OpenSSL Project
  Copyright (c) 1995-1998 Eric A. Young, Tim J. Hudson

--- a/crypto/cms/cms_pwri.c
+++ b/crypto/cms/cms_pwri.c
@@ -215,7 +215,7 @@ static int kek_unwrap_key(unsigned char *out, size_t *outlen,
         /* Check byte failure */
         goto err;
     }
-    if (inlen < (size_t)(tmp[0] - 4)) {
+    if (inlen < 4 + (size_t)tmp[0]) {
         /* Invalid length value */
         goto err;
     }

--- a/include/openssl/opensslv.h
+++ b/include/openssl/opensslv.h
@@ -40,7 +40,7 @@ extern "C" {
  *  major minor fix final patch/beta)
  */
 # define OPENSSL_VERSION_NUMBER  0x101011bfL
-# define OPENSSL_VERSION_TEXT    "OpenSSL 1.1.1zb  20 Jan 2025"
+# define OPENSSL_VERSION_TEXT    "OpenSSL 1.1.1zd  30 Sep 2025"
 
 /*-
  * The macros below are to be used for shared library (.so, .dll, ...)


### PR DESCRIPTION
Added fix for latest CVE-2025-9230.